### PR TITLE
Add metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project aims to provide feature parity with the [Kinesis Client Library](ht
 
 - [ ] Balances shard-worker associations when shards are split or merged
 
-- [ ] Instrumentation that supports CloudWatch
+- [x] Instrumentation that supports CloudWatch (partial support)
 
 ## Development Status
 

--- a/checkpointer.go
+++ b/checkpointer.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultLeaseDuration = 30
+	defaultLeaseDuration = 30000
 	// ErrLeaseNotAquired is returned when we failed to get a lock on the shard
 	ErrLeaseNotAquired = "Lease is already held by another node"
 	// ErrInvalidDynamoDBSchema is returned when there are one or more fields missing from the table
@@ -71,7 +71,7 @@ func (checkpointer *DynamoCheckpoint) Init() error {
 
 // GetLease attempts to gain a lock on the given shard
 func (checkpointer *DynamoCheckpoint) GetLease(shard *shardStatus, newAssignTo string) error {
-	newLeaseTimeout := time.Now().Add(time.Duration(checkpointer.LeaseDuration) * time.Second).UTC()
+	newLeaseTimeout := time.Now().Add(time.Duration(checkpointer.LeaseDuration) * time.Millisecond).UTC()
 	newLeaseTimeoutString := newLeaseTimeout.Format(time.RFC3339)
 	currentCheckpoint, err := checkpointer.getItem(shard.ID)
 	if err != nil {

--- a/checkpointer_test.go
+++ b/checkpointer_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	log "github.com/sirupsen/logrus"
 )
 
 type mockDynamoDB struct {
@@ -54,7 +53,6 @@ func TestDoesTableExist(t *testing.T) {
 }
 
 func TestGetLeaseNotAquired(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
 	svc := &mockDynamoDB{tableExist: true}
 	checkpoint := &DynamoCheckpoint{
 		TableName: "TableName",

--- a/consumer.go
+++ b/consumer.go
@@ -54,21 +54,30 @@ type KinesisConsumer struct {
 	TableName            string
 	EmptyRecordBackoffMs int
 	LeaseDuration        int
+	Monitoring           MonitoringConfiguration
 	svc                  kinesisiface.KinesisAPI
 	checkpointer         Checkpointer
 	stop                 *chan struct{}
 	shardStatus          map[string]*shardStatus
 	consumerID           string
 	sigs                 *chan os.Signal
+	mService             monitoringService
 }
 
 // StartConsumer starts the RecordConsumer, calls Init and starts sending records to ProcessRecords
 func (kc *KinesisConsumer) StartConsumer() error {
-	log.SetLevel(log.DebugLevel)
 	// Set Defaults
 	if kc.EmptyRecordBackoffMs == 0 {
 		kc.EmptyRecordBackoffMs = defaultEmptyRecordBackoffMs
 	}
+
+	kc.consumerID = uuid.New().String()
+
+	err := kc.Monitoring.init(kc.StreamName, kc.consumerID)
+	if err != nil {
+		log.Errorf("Failed to start monitoring service: %s", err)
+	}
+	kc.mService = kc.Monitoring.service
 
 	if kc.svc == nil && kc.checkpointer == nil {
 		log.Debugf("Creating Kinesis Session")
@@ -105,8 +114,7 @@ func (kc *KinesisConsumer) StartConsumer() error {
 	stopChan := make(chan struct{})
 	kc.stop = &stopChan
 
-	kc.consumerID = uuid.New().String()
-	err := kc.getShardIDs("")
+	err = kc.getShardIDs("")
 	if err != nil {
 		log.Errorf("Error getting Kinesis shards: %s", err)
 		return err
@@ -147,6 +155,8 @@ func (kc *KinesisConsumer) eventLoop() {
 				}
 				log.Fatal(err)
 			}
+
+			kc.mService.leaseGained(shard.ID)
 
 			kc.RecordConsumer.Init(shard.ID)
 			log.Debugf("Starting consumer for shard %s on %s", shard.ID, shard.AssignedTo)
@@ -251,6 +261,7 @@ func (kc *KinesisConsumer) getRecords(shardID string) {
 	var retriedErrors int
 
 	for {
+		getRecordsStartTime := time.Now()
 		if time.Now().UTC().After(shard.LeaseTimeout.Add(-5 * time.Second)) {
 			err = kc.checkpointer.GetLease(shard, kc.consumerID)
 			if err != nil {
@@ -258,6 +269,7 @@ func (kc *KinesisConsumer) getRecords(shardID string) {
 					shard.mux.Lock()
 					defer shard.mux.Unlock()
 					shard.AssignedTo = ""
+					kc.mService.leaseLost(shard.ID)
 					return
 				}
 				log.Fatal(err)
@@ -282,6 +294,7 @@ func (kc *KinesisConsumer) getRecords(shardID string) {
 		retriedErrors = 0
 
 		var records []*Records
+		var recordBytes int64
 		for _, r := range getResp.Records {
 			record := &Records{
 				Data:           r.Data,
@@ -289,9 +302,14 @@ func (kc *KinesisConsumer) getRecords(shardID string) {
 				SequenceNumber: *r.SequenceNumber,
 			}
 			records = append(records, record)
+			recordBytes += int64(len(record.Data))
 			log.Debugf("Processing record %s", *r.SequenceNumber)
 		}
+		processRecordsStartTime := time.Now()
 		kc.RecordConsumer.ProcessRecords(records, kc)
+		// Convert from nanoseconds to milliseconds
+		processedRecordsTiming := time.Since(processRecordsStartTime) / 1000000
+		kc.mService.recordProcessRecordsTime(shard.ID, float64(processedRecordsTiming))
 
 		if len(records) == 0 {
 			time.Sleep(time.Duration(kc.EmptyRecordBackoffMs) * time.Millisecond)
@@ -302,6 +320,14 @@ func (kc *KinesisConsumer) getRecords(shardID string) {
 			shard.mux.Unlock()
 			kc.checkpointer.CheckpointSequence(shard)
 		}
+
+		kc.mService.incrRecordsProcessed(shard.ID, len(records))
+		kc.mService.incrBytesProcessed(shard.ID, recordBytes)
+		kc.mService.millisBehindLatest(shard.ID, *getResp.MillisBehindLatest)
+
+		// Convert from nanoseconds to milliseconds
+		getRecordsTime := time.Since(getRecordsStartTime) / 1000000
+		kc.mService.recordGetRecordsTime(shard.ID, float64(getRecordsTime))
 
 		// The shard has been closed, so no new records can be read from it
 		if getResp.NextShardIterator == nil {
@@ -315,7 +341,7 @@ func (kc *KinesisConsumer) getRecords(shardID string) {
 		case <-*kc.stop:
 			kc.RecordConsumer.Shutdown()
 			return
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(1 * time.Nanosecond):
 		}
 	}
 }

--- a/consumer.go
+++ b/consumer.go
@@ -330,7 +330,7 @@ func (kc *KinesisConsumer) getRecords(shardID string) {
 
 		kc.mService.incrRecordsProcessed(shard.ID, len(records))
 		kc.mService.incrBytesProcessed(shard.ID, recordBytes)
-		kc.mService.millisBehindLatest(shard.ID, *getResp.MillisBehindLatest)
+		kc.mService.millisBehindLatest(shard.ID, float64(*getResp.MillisBehindLatest))
 
 		// Convert from nanoseconds to milliseconds
 		getRecordsTime := time.Since(getRecordsStartTime) / 1000000

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -129,6 +129,7 @@ func TestStartConsumer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got unexpected error from StartConsumer: %s", err)
 	}
+	time.Sleep(200 * time.Millisecond)
 	kc.Shutdown()
 	if consumer.ShardID != "00000001" {
 		t.Errorf("Expected shardId to be set to 00000001, but got: %s", consumer.ShardID)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -140,7 +140,7 @@ func TestStartConsumer(t *testing.T) {
 		t.Errorf("Expected record to be \"Hello World\", got %s", consumer.Records[1].Data)
 	}
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 	if consumer.IsShutdown != true {
 		t.Errorf("Expected consumer to be shutdown but it was not")
 	}
@@ -164,7 +164,7 @@ func TestStartConsumer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got unexpected error from StartConsumer: %s", err)
 	}
-	time.Sleep(1 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 	kc.Shutdown()
 	if len(consumer.Records) != 2 {
 		t.Errorf("Expected there to be two records from Kinesis, got %s", consumer.Records)

--- a/example_test.go
+++ b/example_test.go
@@ -35,6 +35,8 @@ func ExampleRecordConsumer() {
 		TableName:            "gokini",
 		EmptyRecordBackoffMs: 1000,
 	}
+
+	// Send records to our kinesis stream so we have something to process
 	pushRecordToKinesis("KINESIS_STREAM", []byte("foo"))
 
 	err := kc.StartConsumer()

--- a/example_test.go
+++ b/example_test.go
@@ -37,7 +37,7 @@ func ExampleRecordConsumer() {
 	}
 
 	// Send records to our kinesis stream so we have something to process
-	pushRecordToKinesis("KINESIS_STREAM", []byte("foo"))
+	pushRecordToKinesis("KINESIS_STREAM", []byte("foo"), true)
 
 	err := kc.StartConsumer()
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -45,7 +45,7 @@ func ExampleRecordConsumer() {
 	}
 
 	// Wait for it to do it's thing
-	time.Sleep(1 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 	kc.Shutdown()
 
 	// Output:

--- a/integration_test.go
+++ b/integration_test.go
@@ -136,7 +136,7 @@ func TestPrometheusMonitoring(t *testing.T) {
 		LeaseDuration:        1,
 		Monitoring: MonitoringConfiguration{
 			MonitoringService: "prometheus",
-			Prometheus: Prometheus{
+			Prometheus: prometheusMonitoringService{
 				ListenAddress: ":8080",
 			},
 		},

--- a/integration_test.go
+++ b/integration_test.go
@@ -147,7 +147,7 @@ func TestPrometheusMonitoring(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error starting consumer %s", err)
 	}
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 
 	res, err := http.Get("http://localhost:8080/metrics")
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -48,7 +48,7 @@ func TestCheckpointRecovery(t *testing.T) {
 	}
 
 	kc.Shutdown()
-	time.Sleep(1 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 
 	kc = &KinesisConsumer{
 		StreamName:        "checkpoint_recovery",
@@ -62,7 +62,7 @@ func TestCheckpointRecovery(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error starting consumer %s", err)
 	}
-	time.Sleep(1 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 	for sequenceID, timesSequenceProcessed := range rc.processedRecords {
 		fmt.Printf("seqenceID: %s, processed %d time(s)\n", sequenceID, timesSequenceProcessed)
 		if timesSequenceProcessed > 1 {
@@ -92,7 +92,7 @@ func TestCheckpointGainLock(t *testing.T) {
 	}
 
 	kc.Shutdown()
-	time.Sleep(1 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 
 	kc = &KinesisConsumer{
 		StreamName:        "checkpoint_gain_lock",
@@ -107,7 +107,7 @@ func TestCheckpointGainLock(t *testing.T) {
 		t.Errorf("Error starting consumer %s", err)
 	}
 	pushRecordToKinesis("checkpoint_gain_lock", []byte("abcd"))
-	time.Sleep(1 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 	if len(rc.processedRecords) != 2 {
 		t.Errorf("Expected to have processed 2 records")
 		for sequenceId, timesProcessed := range rc.processedRecords {

--- a/integration_test.go
+++ b/integration_test.go
@@ -86,7 +86,7 @@ func TestCheckpointGainLock(t *testing.T) {
 		RecordConsumer:       rc,
 		TableName:            "checkpoint_gain_lock",
 		EmptyRecordBackoffMs: 2000,
-		LeaseDuration:        1,
+		LeaseDuration:        100,
 	}
 	pushRecordToKinesis("checkpoint_gain_lock", []byte("abcd"), true)
 
@@ -103,7 +103,7 @@ func TestCheckpointGainLock(t *testing.T) {
 		ShardIteratorType: "TRIM_HORIZON",
 		RecordConsumer:    rc,
 		TableName:         "checkpoint_gain_lock",
-		LeaseDuration:     1,
+		LeaseDuration:     100,
 	}
 
 	err = kc.StartConsumer()

--- a/integration_test.go
+++ b/integration_test.go
@@ -162,12 +162,6 @@ func TestPrometheusMonitoring(t *testing.T) {
 		t.Errorf("Error reading monitoring response %s", err)
 	}
 
-	// # HELP gokini_processed_bytes Number of bytes processed
-	//# TYPE gokini_processed_bytes counter
-	//gokini_processed_bytes{kinesisStream="KINESIS_STREAM",shard="shardId-000000000000"} 9
-	//# HELP gokini_processed_records Number of records processed
-	//# TYPE gokini_processed_records counter
-	//gokini_processed_records{kinesisStream="KINESIS_STREAM",shard="shardId-000000000000"} 3
 	if *parsed["gokini_processed_bytes"].Metric[0].Counter.Value != float64(4) {
 		t.Errorf("Expected to have read 4 bytes, got %d", int(*parsed["gokini_processed_bytes"].Metric[0].Counter.Value))
 	}
@@ -176,7 +170,7 @@ func TestPrometheusMonitoring(t *testing.T) {
 		t.Errorf("Expected to have read 1 records, got %d", int(*parsed["gokini_processed_records"].Metric[0].Counter.Value))
 	}
 
-	if *parsed["gokini_leases_held"].Metric[0].Counter.Value != float64(1) {
+	if *parsed["gokini_leases_held"].Metric[0].Gauge.Value != float64(1) {
 		t.Errorf("Expected to have 1 lease held, got %d", int(*parsed["gokini_leases_held"].Metric[0].Counter.Value))
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -51,8 +51,8 @@ func TestCheckpointRecovery(t *testing.T) {
 		t.Errorf("Error starting consumer %s", err)
 	}
 
-	kc.Shutdown()
 	time.Sleep(200 * time.Millisecond)
+	kc.Shutdown()
 
 	kc = &KinesisConsumer{
 		StreamName:        "checkpoint_recovery",
@@ -95,8 +95,8 @@ func TestCheckpointGainLock(t *testing.T) {
 		t.Errorf("Error starting consumer %s", err)
 	}
 
-	kc.Shutdown()
 	time.Sleep(200 * time.Millisecond)
+	kc.Shutdown()
 
 	kc = &KinesisConsumer{
 		StreamName:        "checkpoint_gain_lock",

--- a/integration_test.go
+++ b/integration_test.go
@@ -44,7 +44,7 @@ func TestCheckpointRecovery(t *testing.T) {
 		EmptyRecordBackoffMs: 2000,
 		LeaseDuration:        1,
 	}
-	pushRecordToKinesis("checkpoint_recovery", []byte("abcd"))
+	pushRecordToKinesis("checkpoint_recovery", []byte("abcd"), true)
 
 	err := kc.StartConsumer()
 	if err != nil {
@@ -88,7 +88,7 @@ func TestCheckpointGainLock(t *testing.T) {
 		EmptyRecordBackoffMs: 2000,
 		LeaseDuration:        1,
 	}
-	pushRecordToKinesis("checkpoint_gain_lock", []byte("abcd"))
+	pushRecordToKinesis("checkpoint_gain_lock", []byte("abcd"), true)
 
 	err := kc.StartConsumer()
 	if err != nil {
@@ -110,7 +110,7 @@ func TestCheckpointGainLock(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error starting consumer %s", err)
 	}
-	pushRecordToKinesis("checkpoint_gain_lock", []byte("abcd"))
+	pushRecordToKinesis("checkpoint_gain_lock", []byte("abcd"), false)
 	time.Sleep(200 * time.Millisecond)
 	if len(rc.processedRecords) != 2 {
 		t.Errorf("Expected to have processed 2 records")
@@ -141,7 +141,7 @@ func TestPrometheusMonitoring(t *testing.T) {
 			},
 		},
 	}
-	pushRecordToKinesis("prometheus_monitoring", []byte("abcd"))
+	pushRecordToKinesis("prometheus_monitoring", []byte("abcd"), true)
 
 	err := kc.StartConsumer()
 	if err != nil {

--- a/monitoring.go
+++ b/monitoring.go
@@ -3,7 +3,13 @@ package gokini
 import (
 	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -12,7 +18,8 @@ import (
 // MonitoringConfiguration allows you to configure how record processing metrics are exposed
 type MonitoringConfiguration struct {
 	MonitoringService string // Type of monitoring to expose. Supported types are "prometheus"
-	Prometheus        Prometheus
+	Prometheus        prometheusMonitoringService
+	CloudWatch        cloudWatchMonitoringService
 	service           monitoringService
 }
 
@@ -20,7 +27,7 @@ type monitoringService interface {
 	init() error
 	incrRecordsProcessed(string, int)
 	incrBytesProcessed(string, int64)
-	millisBehindLatest(string, int64)
+	millisBehindLatest(string, float64)
 	leaseGained(string)
 	leaseLost(string)
 	leaseRenewed(string)
@@ -39,14 +46,17 @@ func (m *MonitoringConfiguration) init(streamName string, workerID string) error
 		m.Prometheus.KinesisStream = streamName
 		m.Prometheus.WorkerID = workerID
 		m.service = &m.Prometheus
+	case "cloudwatch":
+		m.CloudWatch.KinesisStream = streamName
+		m.CloudWatch.WorkerID = workerID
+		m.service = &m.CloudWatch
 	default:
 		return fmt.Errorf("Invalid monitoring service type %s", m.MonitoringService)
 	}
 	return m.service.init()
 }
 
-// Prometheus configures an HTTP endpoint for Prometheus to scrape
-type Prometheus struct {
+type prometheusMonitoringService struct {
 	ListenAddress      string
 	Namespace          string
 	KinesisStream      string
@@ -62,7 +72,7 @@ type Prometheus struct {
 
 const defaultNamespace = "gokini"
 
-func (p *Prometheus) init() error {
+func (p *prometheusMonitoringService) init() error {
 	if p.Namespace == "" {
 		p.Namespace = defaultNamespace
 	}
@@ -122,35 +132,35 @@ func (p *Prometheus) init() error {
 	return nil
 }
 
-func (p *Prometheus) incrRecordsProcessed(shard string, count int) {
+func (p *prometheusMonitoringService) incrRecordsProcessed(shard string, count int) {
 	p.processedRecords.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Add(float64(count))
 }
 
-func (p *Prometheus) incrBytesProcessed(shard string, count int64) {
+func (p *prometheusMonitoringService) incrBytesProcessed(shard string, count int64) {
 	p.processedBytes.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Add(float64(count))
 }
 
-func (p *Prometheus) millisBehindLatest(shard string, millSeconds int64) {
-	p.behindLatestMillis.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Set(float64(millSeconds))
+func (p *prometheusMonitoringService) millisBehindLatest(shard string, millSeconds float64) {
+	p.behindLatestMillis.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Set(millSeconds)
 }
 
-func (p *Prometheus) leaseGained(shard string) {
+func (p *prometheusMonitoringService) leaseGained(shard string) {
 	p.leasesHeld.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream, "workerID": p.WorkerID}).Inc()
 }
 
-func (p *Prometheus) leaseLost(shard string) {
+func (p *prometheusMonitoringService) leaseLost(shard string) {
 	p.leasesHeld.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream, "workerID": p.WorkerID}).Dec()
 }
 
-func (p *Prometheus) leaseRenewed(shard string) {
+func (p *prometheusMonitoringService) leaseRenewed(shard string) {
 	p.leaseRenewals.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream, "workerID": p.WorkerID}).Inc()
 }
 
-func (p *Prometheus) recordGetRecordsTime(shard string, time float64) {
+func (p *prometheusMonitoringService) recordGetRecordsTime(shard string, time float64) {
 	p.getRecordsTime.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Observe(time)
 }
 
-func (p *Prometheus) recordProcessRecordsTime(shard string, time float64) {
+func (p *prometheusMonitoringService) recordProcessRecordsTime(shard string, time float64) {
 	p.processRecordsTime.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Observe(time)
 }
 
@@ -160,11 +170,273 @@ func (n *noopMonitoringService) init() error {
 	return nil
 }
 
-func (n *noopMonitoringService) incrRecordsProcessed(shard string, count int)        {}
-func (n *noopMonitoringService) incrBytesProcessed(shard string, count int64)        {}
-func (n *noopMonitoringService) millisBehindLatest(shard string, millSeconds int64)  {}
-func (n *noopMonitoringService) leaseGained(shard string)                            {}
-func (n *noopMonitoringService) leaseLost(shard string)                              {}
-func (n *noopMonitoringService) leaseRenewed(shard string)                           {}
-func (n *noopMonitoringService) recordGetRecordsTime(shard string, time float64)     {}
-func (n *noopMonitoringService) recordProcessRecordsTime(shard string, time float64) {}
+func (n *noopMonitoringService) incrRecordsProcessed(shard string, count int)         {}
+func (n *noopMonitoringService) incrBytesProcessed(shard string, count int64)         {}
+func (n *noopMonitoringService) millisBehindLatest(shard string, millSeconds float64) {}
+func (n *noopMonitoringService) leaseGained(shard string)                             {}
+func (n *noopMonitoringService) leaseLost(shard string)                               {}
+func (n *noopMonitoringService) leaseRenewed(shard string)                            {}
+func (n *noopMonitoringService) recordGetRecordsTime(shard string, time float64)      {}
+func (n *noopMonitoringService) recordProcessRecordsTime(shard string, time float64)  {}
+
+type cloudWatchMonitoringService struct {
+	Namespace     string
+	KinesisStream string
+	WorkerID      string
+	// What granularity we should send metrics to CW at. Note setting this to 1 will cost quite a bit of money
+	// At the time of writing (March 2018) about US$200 per month
+	ResolutionSec int
+	svc           cloudwatchiface.CloudWatchAPI
+	shardMetrics  map[string]*cloudWatchMetrics
+}
+
+type cloudWatchMetrics struct {
+	processedRecords   int64
+	processedBytes     int64
+	behindLatestMillis []float64
+	leasesHeld         int64
+	leaseRenewals      int64
+	getRecordsTime     []float64
+	processRecordsTime []float64
+	sync.Mutex
+}
+
+func (cw *cloudWatchMonitoringService) init() error {
+	if cw.ResolutionSec == 0 {
+		cw.ResolutionSec = 60
+	}
+
+	session, err := session.NewSessionWithOptions(
+		session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	cw.svc = cloudwatch.New(session)
+	cw.shardMetrics = make(map[string]*cloudWatchMetrics)
+	return nil
+}
+
+func (cw *cloudWatchMonitoringService) flushDaemon() {
+	previousFlushTime := time.Now()
+	resolutionDuration := time.Duration(cw.ResolutionSec) * time.Second
+	for {
+		time.Sleep(resolutionDuration - time.Now().Sub(previousFlushTime))
+		err := cw.flush()
+		if err != nil {
+			log.Errorln("Error sending metrics to CloudWatch", err)
+		}
+		previousFlushTime = time.Now()
+	}
+}
+
+func (cw *cloudWatchMonitoringService) flush() error {
+	for shard, metric := range cw.shardMetrics {
+		metric.Lock()
+		defaultDimensions := []*cloudwatch.Dimension{
+			&cloudwatch.Dimension{
+				Name:  aws.String("shard"),
+				Value: &shard,
+			},
+			&cloudwatch.Dimension{
+				Name:  aws.String("KinesisStreamName"),
+				Value: &cw.KinesisStream,
+			},
+		}
+		leaseDimensions := make([]*cloudwatch.Dimension, len(defaultDimensions))
+		copy(defaultDimensions, leaseDimensions)
+		leaseDimensions = append(leaseDimensions, &cloudwatch.Dimension{
+			Name:  aws.String("WorkerID"),
+			Value: &cw.WorkerID,
+		})
+		metricTimestamp := time.Now()
+		_, err := cw.svc.PutMetricData(&cloudwatch.PutMetricDataInput{
+			Namespace: aws.String(cw.Namespace),
+			MetricData: []*cloudwatch.MetricDatum{
+				&cloudwatch.MetricDatum{
+					Dimensions: defaultDimensions,
+					MetricName: aws.String("RecordsProcessed"),
+					Unit:       aws.String("Count"),
+					Timestamp:  &metricTimestamp,
+					Value:      aws.Float64(float64(metric.processedRecords)),
+				},
+				&cloudwatch.MetricDatum{
+					Dimensions: defaultDimensions,
+					MetricName: aws.String("DataBytesProcessed"),
+					Unit:       aws.String("Byte"),
+					Timestamp:  &metricTimestamp,
+					Value:      aws.Float64(float64(metric.processedBytes)),
+				},
+				&cloudwatch.MetricDatum{
+					Dimensions: defaultDimensions,
+					MetricName: aws.String("MillisBehindLatest"),
+					Unit:       aws.String("Milliseconds"),
+					Timestamp:  &metricTimestamp,
+					StatisticValues: &cloudwatch.StatisticSet{
+						SampleCount: aws.Float64(float64(len(metric.behindLatestMillis))),
+						Sum:         sumFloat64(metric.behindLatestMillis),
+						Maximum:     maxFloat64(metric.behindLatestMillis),
+						Minimum:     minFloat64(metric.behindLatestMillis),
+					},
+				},
+				&cloudwatch.MetricDatum{
+					Dimensions: defaultDimensions,
+					MetricName: aws.String("KinesisDataFetcher.getRecords.Time"),
+					Unit:       aws.String("Milliseconds"),
+					Timestamp:  &metricTimestamp,
+					StatisticValues: &cloudwatch.StatisticSet{
+						SampleCount: aws.Float64(float64(len(metric.getRecordsTime))),
+						Sum:         sumFloat64(metric.getRecordsTime),
+						Maximum:     maxFloat64(metric.getRecordsTime),
+						Minimum:     minFloat64(metric.getRecordsTime),
+					},
+				},
+				&cloudwatch.MetricDatum{
+					Dimensions: defaultDimensions,
+					MetricName: aws.String("RecordProcessor.processRecords.Time"),
+					Unit:       aws.String("Milliseconds"),
+					Timestamp:  &metricTimestamp,
+					StatisticValues: &cloudwatch.StatisticSet{
+						SampleCount: aws.Float64(float64(len(metric.processRecordsTime))),
+						Sum:         sumFloat64(metric.processRecordsTime),
+						Maximum:     maxFloat64(metric.processRecordsTime),
+						Minimum:     minFloat64(metric.processRecordsTime),
+					},
+				},
+				&cloudwatch.MetricDatum{
+					Dimensions: leaseDimensions,
+					MetricName: aws.String("RenewLease.Success"),
+					Unit:       aws.String("Count"),
+					Timestamp:  &metricTimestamp,
+					Value:      aws.Float64(float64(metric.leaseRenewals)),
+				},
+				&cloudwatch.MetricDatum{
+					Dimensions: leaseDimensions,
+					MetricName: aws.String("CurrentLeases"),
+					Unit:       aws.String("Count"),
+					Timestamp:  &metricTimestamp,
+					Value:      aws.Float64(float64(metric.leasesHeld)),
+				},
+			},
+		})
+		if err == nil {
+			metric.processedRecords = 0
+			metric.processedBytes = 0
+			metric.behindLatestMillis = []float64{}
+			metric.leaseRenewals = 0
+			metric.getRecordsTime = []float64{}
+			metric.processRecordsTime = []float64{}
+		}
+		metric.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (cw *cloudWatchMonitoringService) incrRecordsProcessed(shard string, count int) {
+	if _, ok := cw.shardMetrics[shard]; !ok {
+		cw.shardMetrics[shard] = &cloudWatchMetrics{}
+	}
+	cw.shardMetrics[shard].Lock()
+	defer cw.shardMetrics[shard].Unlock()
+	cw.shardMetrics[shard].processedRecords += int64(count)
+}
+
+func (cw *cloudWatchMonitoringService) incrBytesProcessed(shard string, count int64) {
+	if _, ok := cw.shardMetrics[shard]; !ok {
+		cw.shardMetrics[shard] = &cloudWatchMetrics{}
+	}
+	cw.shardMetrics[shard].Lock()
+	defer cw.shardMetrics[shard].Unlock()
+	cw.shardMetrics[shard].processedBytes += count
+}
+
+func (cw *cloudWatchMonitoringService) millisBehindLatest(shard string, millSeconds float64) {
+	if _, ok := cw.shardMetrics[shard]; !ok {
+		cw.shardMetrics[shard] = &cloudWatchMetrics{}
+	}
+	cw.shardMetrics[shard].Lock()
+	defer cw.shardMetrics[shard].Unlock()
+	cw.shardMetrics[shard].behindLatestMillis = append(cw.shardMetrics[shard].behindLatestMillis, millSeconds)
+}
+
+func (cw *cloudWatchMonitoringService) leaseGained(shard string) {
+	if _, ok := cw.shardMetrics[shard]; !ok {
+		cw.shardMetrics[shard] = &cloudWatchMetrics{}
+	}
+	cw.shardMetrics[shard].Lock()
+	defer cw.shardMetrics[shard].Unlock()
+	cw.shardMetrics[shard].leasesHeld++
+}
+
+func (cw *cloudWatchMonitoringService) leaseLost(shard string) {
+	if _, ok := cw.shardMetrics[shard]; !ok {
+		cw.shardMetrics[shard] = &cloudWatchMetrics{}
+	}
+	cw.shardMetrics[shard].Lock()
+	defer cw.shardMetrics[shard].Unlock()
+	cw.shardMetrics[shard].leasesHeld--
+}
+
+func (cw *cloudWatchMonitoringService) leaseRenewed(shard string) {
+	if _, ok := cw.shardMetrics[shard]; !ok {
+		cw.shardMetrics[shard] = &cloudWatchMetrics{}
+	}
+	cw.shardMetrics[shard].Lock()
+	defer cw.shardMetrics[shard].Unlock()
+	cw.shardMetrics[shard].leaseRenewals++
+}
+
+func (cw *cloudWatchMonitoringService) recordGetRecordsTime(shard string, time float64) {
+	if _, ok := cw.shardMetrics[shard]; !ok {
+		cw.shardMetrics[shard] = &cloudWatchMetrics{}
+	}
+	cw.shardMetrics[shard].Lock()
+	defer cw.shardMetrics[shard].Unlock()
+	cw.shardMetrics[shard].getRecordsTime = append(cw.shardMetrics[shard].getRecordsTime, time)
+}
+func (cw *cloudWatchMonitoringService) recordProcessRecordsTime(shard string, time float64) {
+	if _, ok := cw.shardMetrics[shard]; !ok {
+		cw.shardMetrics[shard] = &cloudWatchMetrics{}
+	}
+	cw.shardMetrics[shard].Lock()
+	defer cw.shardMetrics[shard].Unlock()
+	cw.shardMetrics[shard].processRecordsTime = append(cw.shardMetrics[shard].processRecordsTime, time)
+}
+
+func sumFloat64(slice []float64) *float64 {
+	sum := float64(0)
+	for _, num := range slice {
+		sum += num
+	}
+	return &sum
+}
+
+func maxFloat64(slice []float64) *float64 {
+	if len(slice) < 1 {
+		return aws.Float64(0)
+	}
+	max := slice[0]
+	for _, num := range slice {
+		if num > max {
+			max = num
+		}
+	}
+	return &max
+}
+
+func minFloat64(slice []float64) *float64 {
+	if len(slice) < 1 {
+		return aws.Float64(0)
+	}
+	min := slice[0]
+	for _, num := range slice {
+		if num < min {
+			min = num
+		}
+	}
+	return &min
+}

--- a/monitoring.go
+++ b/monitoring.go
@@ -1,0 +1,170 @@
+package gokini
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+)
+
+// MonitoringConfiguration allows you to configure how record processing metrics are exposed
+type MonitoringConfiguration struct {
+	MonitoringService string // Type of monitoring to expose. Supported types are "prometheus"
+	Prometheus        Prometheus
+	service           monitoringService
+}
+
+type monitoringService interface {
+	init() error
+	incrRecordsProcessed(string, int)
+	incrBytesProcessed(string, int64)
+	millisBehindLatest(string, int64)
+	leaseGained(string)
+	leaseLost(string)
+	leaseRenewed(string)
+	recordGetRecordsTime(string, float64)
+	recordProcessRecordsTime(string, float64)
+}
+
+func (m *MonitoringConfiguration) init(streamName string, workerID string) error {
+	if m.MonitoringService == "" {
+		m.service = &noopMonitoringService{}
+		return nil
+	}
+
+	switch m.MonitoringService {
+	case "prometheus":
+		m.Prometheus.KinesisStream = streamName
+		m.Prometheus.WorkerID = workerID
+		m.service = &m.Prometheus
+	default:
+		return fmt.Errorf("Invalid monitoring service type %s", m.MonitoringService)
+	}
+	return m.service.init()
+}
+
+// Prometheus configures an HTTP endpoint for Prometheus to scrape
+type Prometheus struct {
+	ListenAddress      string
+	Namespace          string
+	KinesisStream      string
+	WorkerID           string
+	processedRecords   *prometheus.CounterVec
+	processedBytes     *prometheus.CounterVec
+	behindLatestMillis *prometheus.GaugeVec
+	leasesHeld         *prometheus.GaugeVec
+	leaseRenewals      *prometheus.CounterVec
+	getRecordsTime     *prometheus.HistogramVec
+	processRecordsTime *prometheus.HistogramVec
+}
+
+const defaultNamespace = "gokini"
+
+func (p *Prometheus) init() error {
+	if p.Namespace == "" {
+		p.Namespace = defaultNamespace
+	}
+	p.processedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: p.Namespace + `_processed_bytes`,
+		Help: "Number of bytes processed",
+	}, []string{"kinesisStream", "shard"})
+	p.processedRecords = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: p.Namespace + `_processed_records`,
+		Help: "Number of records processed",
+	}, []string{"kinesisStream", "shard"})
+	p.behindLatestMillis = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: p.Namespace + `_behind_latest_millis`,
+		Help: "The amount of milliseconds processing is behind",
+	}, []string{"kinesisStream", "shard"})
+	p.leasesHeld = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: p.Namespace + `_leases_held`,
+		Help: "The number of leases held by the worker",
+	}, []string{"kinesisStream", "shard", "workerID"})
+	p.leaseRenewals = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: p.Namespace + `_lease_renewals`,
+		Help: "The number of successful lease renewals",
+	}, []string{"kinesisStream", "shard", "workerID"})
+	p.getRecordsTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: p.Namespace + `_get_records_duration_milliseconds`,
+		Help: "The time taken to fetch records and process them",
+	}, []string{"kinesisStream", "shard"})
+	p.processRecordsTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: p.Namespace + `_process_records_duration_milliseconds`,
+		Help: "The time taken to process records",
+	}, []string{"kinesisStream", "shard"})
+
+	metrics := []prometheus.Collector{
+		p.processedBytes,
+		p.processedRecords,
+		p.behindLatestMillis,
+		p.leasesHeld,
+		p.leaseRenewals,
+		p.getRecordsTime,
+		p.processRecordsTime,
+	}
+	for _, metric := range metrics {
+		err := prometheus.Register(metric)
+		if err != nil {
+			return err
+		}
+	}
+
+	http.Handle("/metrics", promhttp.Handler())
+	go func() {
+		log.Debugf("Starting Prometheus listener on %s", p.ListenAddress)
+		err := http.ListenAndServe(p.ListenAddress, nil)
+		if err != nil {
+			log.Errorln("Error starting Prometheus metrics endpoint", err)
+		}
+	}()
+	return nil
+}
+
+func (p *Prometheus) incrRecordsProcessed(shard string, count int) {
+	p.processedRecords.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Add(float64(count))
+}
+
+func (p *Prometheus) incrBytesProcessed(shard string, count int64) {
+	p.processedBytes.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Add(float64(count))
+}
+
+func (p *Prometheus) millisBehindLatest(shard string, millSeconds int64) {
+	p.behindLatestMillis.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Set(float64(millSeconds))
+}
+
+func (p *Prometheus) leaseGained(shard string) {
+	p.leasesHeld.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream, "workerID": p.WorkerID}).Inc()
+}
+
+func (p *Prometheus) leaseLost(shard string) {
+	p.leasesHeld.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream, "workerID": p.WorkerID}).Dec()
+}
+
+func (p *Prometheus) leaseRenewed(shard string) {
+	p.leaseRenewals.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream, "workerID": p.WorkerID}).Inc()
+}
+
+func (p *Prometheus) recordGetRecordsTime(shard string, time float64) {
+	p.getRecordsTime.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Observe(time)
+}
+
+func (p *Prometheus) recordProcessRecordsTime(shard string, time float64) {
+	p.processRecordsTime.With(prometheus.Labels{"shard": shard, "kinesisStream": p.KinesisStream}).Observe(time)
+}
+
+type noopMonitoringService struct{}
+
+func (n *noopMonitoringService) init() error {
+	return nil
+}
+
+func (n *noopMonitoringService) incrRecordsProcessed(shard string, count int)        {}
+func (n *noopMonitoringService) incrBytesProcessed(shard string, count int64)        {}
+func (n *noopMonitoringService) millisBehindLatest(shard string, millSeconds int64)  {}
+func (n *noopMonitoringService) leaseGained(shard string)                            {}
+func (n *noopMonitoringService) leaseLost(shard string)                              {}
+func (n *noopMonitoringService) leaseRenewed(shard string)                           {}
+func (n *noopMonitoringService) recordGetRecordsTime(shard string, time float64)     {}
+func (n *noopMonitoringService) recordProcessRecordsTime(shard string, time float64) {}

--- a/monitoring_test.go
+++ b/monitoring_test.go
@@ -1,0 +1,42 @@
+package gokini
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+)
+
+type mockCloudWatch struct {
+	cloudwatchiface.CloudWatchAPI
+	metricData []*cloudwatch.MetricDatum
+}
+
+func (m *mockCloudWatch) PutMetricData(input *cloudwatch.PutMetricDataInput) (*cloudwatch.PutMetricDataOutput, error) {
+	m.metricData = append(m.metricData, input.MetricData...)
+	return &cloudwatch.PutMetricDataOutput{}, nil
+}
+
+func TestCloudWatchMonitoring(t *testing.T) {
+	mockCW := &mockCloudWatch{}
+	cwService := &cloudWatchMonitoringService{
+		Namespace:     "testCloudWatchMonitoring",
+		KinesisStream: "cloudwatch_monitoring",
+		WorkerID:      "abc123",
+		ResolutionSec: 1,
+		svc:           mockCW,
+		shardMetrics:  map[string]*cloudWatchMetrics{},
+	}
+	cwService.incrRecordsProcessed("00001", 10)
+	err := cwService.flush()
+	if err != nil {
+		t.Errorf("Received error sending data to cloudwatch %s", err)
+	}
+	if len(mockCW.metricData) < 1 {
+		t.Fatal("Expected at least one metric to be sent to cloudwatch")
+	}
+
+	if *mockCW.metricData[0].Value != float64(10) {
+		t.Errorf("Expected metric value to be 10.0, got %f", *mockCW.metricData[0].Value)
+	}
+}


### PR DESCRIPTION
This PR adds metric providers for Prometheus and CloudWatch. Supported metrics are:
- RenewLease.Success
- CurrentLeases
- KinesisDataFetcher.getRecords.Time
- DataBytesProcessed
- RecordsProcessed
- MillisBehindLatest
- RecordProcessor.processRecords.Time

See https://docs.aws.amazon.com/streams/latest/dev/monitoring-with-kcl.html#kcl-metrics-list for a total list of metrics supported by KCL